### PR TITLE
Add config_param "operator_name"

### DIFF
--- a/fluent-plugin-proc_count.gemspec
+++ b/fluent-plugin-proc_count.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubygems-tasks'
+  gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'yard'
 end

--- a/lib/fluent/plugin/in_proc_count.rb
+++ b/lib/fluent/plugin/in_proc_count.rb
@@ -16,15 +16,18 @@ module Fluent
       config_param :tag, :string
       config_param :regexp, :string
       config_param :proc_count, :integer, default: 1
+      config_param :operator_name, :string, default: "equal"
     end
 
     def configure(conf)
       super
-      @processes = @processes.map { |process| 
+      @processes = @processes.map { |process|
         s = OpenStruct.new
         s.regexp = Regexp.new(process.regexp)
         s.proc_count = process.proc_count
         s.tag = process.tag
+        s.operator_name = process.operator_name
+        s.operator = select_operator(process.operator_name)
         s
       }
     end
@@ -49,15 +52,16 @@ module Fluent
     def emit_proc_count
       @processes.each do |process_spec|
         begin
-          records = get_processes(process_spec)
-          if process_spec.proc_count != records.size
+          record_size = get_processes(process_spec).size
+          if !correct_process?(process_spec, record_size)
             router.emit(
               process_spec.tag,
               Fluent::Engine.now,
               {
                 regexp: process_spec.regexp.source,
-                proc_count: records.size,
+                proc_count: record_size,
                 expect_proc_count: process_spec.proc_count,
+                operator_name: process_spec.operator_name,
                 hostname: Socket.gethostname
               }
             )
@@ -66,6 +70,27 @@ module Fluent
           log.error e
         end
       end
+    end
+
+    def select_operator(operator_name)
+      case operator_name.to_sym
+      when :equal
+        "=="
+      when :gather_than
+        ">"
+      when :gather_equal
+        ">="
+      when :less_than
+        "<"
+      when :less_equal
+        "<="
+      else
+        raise Fluent::ConfigError, "proc_count operator allows equal/gather_than/gather_equal/less_than/less_equal"
+      end
+    end
+
+    def correct_process?(process_spec, expect_proc_count)
+      expect_proc_count.public_send(process_spec.operator, process_spec.proc_count.to_i)
     end
 
     def get_processes(process_spec)

--- a/lib/fluent/plugin/in_proc_count.rb
+++ b/lib/fluent/plugin/in_proc_count.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 require 'sys/proctable'
 require 'ostruct'
 


### PR DESCRIPTION
Add config_param "operator_name"

### Example

```
<source **>
  type forward
  port 24224
</source>

<source>
  @type proc_count
  interval 5s
  <process>
    tag proc_count.td-agent
    regexp td-agent
    proc_count 1 
    operator_name gather_equal # default : equal
  </process>
</source>

<match **>
  type stdout
</match>
``` 
If the process name of the regular expression "td-agent" is **not** 1 or more
The log is output as follows

```
2017-01-27 15:05:57 +0900 proc_count.td-agent: {"regexp":"td-agent","proc_count":0,"expect_proc_count":1,"operator_name":"gather_equal","hostname":"ip-0401.local"}
```

For now, you can use five operators.
